### PR TITLE
Add Data Publish Capability

### DIFF
--- a/firmware/src/server.ino
+++ b/firmware/src/server.ino
@@ -57,6 +57,10 @@ int publishMessage(){
     homeAuto.publishMessage("hey there");
 }
 
+int publishSomeData(){
+	homeAuto.publishData("10", "testing");
+}
+
 void setup(void){
   Serial.begin(115200); // Start serial
   pinMode(LED, OUTPUT); // Set LED pin to output
@@ -66,6 +70,7 @@ void setup(void){
   // HomeAuto bindings
   homeAuto.addHandler("ledToggle", &ledToggle);
   homeAuto.addHandler("hello", &publishMessage);
+  homeAuto.addHandler("publishSomeData", &publishSomeData);
   homeAuto.setClient(pClient);
 
 }

--- a/go-server/src/models/stream-message.go
+++ b/go-server/src/models/stream-message.go
@@ -1,0 +1,15 @@
+package models
+
+import (
+	"gopkg.in/mgo.v2/bson"
+	"time"
+)
+
+type (
+	StreamMessage struct {
+		Id        bson.ObjectId `json:"id" bson:"_id,omitempty"`
+		Timestamp time.Time     `json:"timestamp" bson:"timestamp"`
+		Data      string        `json:"data" bson:"data"`
+		Topic     string        `json:"topic" bson:"topic"`
+	}
+)

--- a/go-server/src/mqtt/handleDevices.go
+++ b/go-server/src/mqtt/handleDevices.go
@@ -5,6 +5,7 @@ import (
 	"github.com/surgemq/message"
 	"github.com/suyashkumar/surgemq/service"
 	"os"
+	"regexp"
 	"time"
 )
 
@@ -22,6 +23,12 @@ func onPublish(msg *message.PublishMessage) error {
 		if os.ExpandEnv("LOGGING") != "" {
 			fmt.Println("Topic:", string(msg.Topic()), "Payload:", string(msg.Payload()))
 		}
+	}
+	// Look to see if the published message was a streaming data message
+	// If so, persist the contents to an appropiate db
+	var validDataStream = regexp.MustCompile(`^[^/]*/stream/.*`)
+	if validDataStream.MatchString(string(msg.Topic())) {
+		PersistMessage(string(msg.Payload()), string(msg.Topic()))
 	}
 	return nil
 }

--- a/go-server/src/mqtt/persist-messages.go
+++ b/go-server/src/mqtt/persist-messages.go
@@ -1,0 +1,25 @@
+package mqtt
+
+import (
+	"gopkg.in/mgo.v2"
+	"models"
+	"time"
+)
+
+func PersistMessage(message string, topic string) {
+	session, err := mgo.Dial("localhost")
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	c := session.DB("homeauto").C("streammessages")
+	err = c.Insert(&models.StreamMessage{
+		Data:      message,
+		Timestamp: time.Now(),
+		Topic:     topic,
+	})
+	if err != nil {
+		panic(err)
+	}
+}

--- a/go-server/src/routes/dataStreams.go
+++ b/go-server/src/routes/dataStreams.go
@@ -20,7 +20,8 @@ func GetStreamedMessages(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	c := session.DB("homeauto").C("streammessages")
 
 	var results []models.StreamMessage
-	err = c.Find(bson.M{"Topic": ps.ByName("deviceName") + "/stream/" + ps.ByName("streamName")}).All(&results)
+	topicName := ps.ByName("deviceName") + "/stream/" + ps.ByName("streamName")
+	err = c.Find(bson.M{"topic": topicName}).All(&results)
 	if err != nil {
 		panic(err)
 	}

--- a/go-server/src/routes/dataStreams.go
+++ b/go-server/src/routes/dataStreams.go
@@ -1,0 +1,30 @@
+package routes
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/julienschmidt/httprouter"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"models"
+	"net/http"
+)
+
+func GetStreamedMessages(w http.ResponseWriter, r *http.Request, ps httprouter.Params, hc *HomeAutoClaims) {
+	session, err := mgo.Dial("localhost")
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	c := session.DB("homeauto").C("streammessages")
+
+	var results []models.StreamMessage
+	err = c.Find(bson.M{"Topic": ps.ByName("deviceName") + "/stream/" + ps.ByName("streamName")}).All(&results)
+	if err != nil {
+		panic(err)
+	}
+	resBytes, _ := json.Marshal(results)
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, string(resBytes))
+}

--- a/go-server/src/server/server.go
+++ b/go-server/src/server/server.go
@@ -10,6 +10,7 @@ import (
 func main() {
 	router := httprouter.New()
 	router.GET("/api/send/:deviceName/:funcName", routes.AuthMiddlewareGenerator(routes.Send))
+	router.GET("/api/streams/:deviceName/:streamName", routes.AuthMiddlewareGenerator(routes.GetStreamedMessages))
 	router.GET("/api/users", routes.ListUsers)
 	router.POST("/api/auth", routes.Auth)
 	router.GET("/api/new", routes.New)


### PR DESCRIPTION
This closes #5. This adds functionality to the server and firmware library to allow users to push arbitrary data from devices to "data streams" on the server that will be automatically persisted to a database (and available to consume later via a `GET /api/streams/:deviceName/:streamName`. 
