### PR TITLE
[Server] Initial User Prefixing + Registration + Error Handling

### DIFF
--- a/server/models/user.go
+++ b/server/models/user.go
@@ -6,6 +6,7 @@ type (
 	User struct {
 		Id       bson.ObjectId `json:"id" bson:"_id,omitempty"`
 		Email    string        `json:"email" bson:"email"`
-		Password string        `json:"password" bson:"password`
+		Password string        `json:"password,omitempty" bson:"password"`
+		Prefix   string        `json:"prefix" bson:"prefix"`
 	}
 )

--- a/server/routes/deviceMessaging.go
+++ b/server/routes/deviceMessaging.go
@@ -14,12 +14,17 @@ type RpcResponse struct {
 	Data    string `json:"data"`
 }
 
+func PrefixedName(deviceName string, prefix string) string {
+	return prefix + deviceName
+}
+
 func Send(w http.ResponseWriter, r *http.Request, ps httprouter.Params, hc *HomeAutoClaims) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	if r.Method == "OPTIONS" {
 		fmt.Println("OPT")
 		return
 	}
+
 	mqtt.SendMessage(ps.ByName("deviceName"), ps.ByName("funcName"))
 	c := make(chan string)
 	end := make(chan string)

--- a/server/server.go
+++ b/server/server.go
@@ -15,7 +15,7 @@ func main() {
 	router.GET("/api/streams/:deviceName/:streamName", routes.AuthMiddlewareGenerator(routes.GetStreamedMessages))
 	router.GET("/api/users", routes.ListUsers)
 	router.POST("/api/auth", routes.Auth)
-	router.GET("/api/new", routes.New)
+	router.POST("/api/register", routes.New)
 	router.GET("/api/auth/test", routes.AuthMiddlewareGenerator(routes.Test))
 	router.GET("/", routes.Hello)
 	router.OPTIONS("/api/*sendPath", routes.Headers)

--- a/server/util/random.go
+++ b/server/util/random.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"math/rand"
+	"time"
+)
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// Basic random string generator
+func GetRandString(n int) string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[r.Int63()%int64(len(letterBytes))]
+	}
+	return string(b)
+
+}


### PR DESCRIPTION
This change implements many of the server side changes for namespaced device access given a user secret prefix (closes #14). Prefixes will not be used when making mqtt device calls until the corresponding firmware changes have been made. 

Other changes include new user registration (with automatic initial prefix generation) [closes #10] and setting up centralized error response handling in `routes` (closing #13)