### PR TITLE
Final Firmware + Server changes to support prefixing

### DIFF
--- a/firmware/src/Conduit.h
+++ b/firmware/src/Conduit.h
@@ -23,8 +23,10 @@ private:
   PubSubClient* _client; // The mqtt client
   const char* _mqtt_server;
   const char* _name;
+  const char* _prefixed_name;
+  const char* _prefix;
 public:
-  Conduit(const char* name, const char* server);
+  Conduit(const char* name, const char* server, const char* prefix);
   Conduit& setClient(PubSubClient& client);
   void addHandler(const char* name, handler f);
   void callHandler(const char* name);

--- a/firmware/src/main.ino
+++ b/firmware/src/main.ino
@@ -25,8 +25,9 @@ device and decide what funciton to all is abstracted away entirely by this libra
 WiFiClient client;
 PubSubClient pClient(client);
 //HomeAuto conduit("suyash1", "home.suyash.io"); // or "suyash", "home.suyash.io"
-Conduit conduit("suyash1", "10.0.0.225"); // or "suyash", "home.suyash.io"
-//HomeAuto conduit("suyash", "home.suyash.io"); // or "suyash", "home.suyash.io"
+//Conduit conduit("suyash1", "10.0.0.225"); // or "suyash", "home.suyash.io"
+Conduit conduit("suyash", "192.168.1.144", "zHqHR0nSBTrIzaAY3JCY510Z"); // or "suyash", "home.suyash.io"
+//Conduit conduit("suyash", "conduit.suyash.io", "a"); // or "suyash", "home.suyash.io"
 int ledStatus = 0;
 
 void startWIFI(){


### PR DESCRIPTION
This change makes the firmware changes needed for device name prefixing (along with the final server side changes to enable it). 

This closes #15 and #7. 