### PR TITLE
Refactor to move "magic values" into #defs.

### DIFF
--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -1,3 +1,4 @@
 .pioenvs
 .clang_complete
 .gcc-flags.json
+.piolibdeps/

--- a/firmware/src/Conduit.cpp
+++ b/firmware/src/Conduit.cpp
@@ -12,6 +12,18 @@ device and decide what funciton to all is abstracted away entirely by this libra
 
 #include "Conduit.h"
 
+#define PREFIXED_NAME_CHARS   35
+#define STATIC_STRING_CHARS   64
+#define RECONNECT_DELAY_MS    5000
+#define CONNECT_DELAY_MS      500
+#define ROOT_NODE_NAME        "ROOT"
+#define DEVICE_PATH_SUFFIX    "/device"
+#define STREAM_PATH_INFIX     "/stream/"
+#define DEFAULT_TOPIC_NAME    "outTopic"
+#define ON_CONNECT_MSG        "!connected"
+#define SERVER_DEFAULT_PORT   1883
+#define STRCMP_SAME           0
+
 typedef struct node {
   handler f;
   const char* name;
@@ -20,7 +32,7 @@ typedef struct node {
 
 node_t* root;
 node_t* current;
-char prefixed_name[35];
+char prefixed_name[PREFIXED_NAME_CHARS];
 WiFiClient client;
 PubSubClient pClient(client);
 
@@ -38,28 +50,28 @@ Conduit::Conduit(const char* name, const char* server, const char* prefix){
 
   // Init linked list
   root = (node_t *)malloc(sizeof(node_t));
-  root->next=0;
-  root->name="ROOT"; // reserved name for root node (for now)
+  root->next = nullptr;
+  root->name = ROOT_NODE_NAME; // reserved name for root node (for now)
   current = root; 
 }
 
 void Conduit::addHandler(const char* name, handler f){
   node *newNode = (node_t*) malloc(sizeof(node_t));
   newNode->f = f;
-  newNode->next=0;
-  newNode->name=name;
-  current->next=newNode;
-  current=newNode;
+  newNode->next = nullptr;
+  newNode->name = name;
+  current->next = newNode;
+  current = newNode;
 }
 
 void Conduit::callHandler(const char* name){
   node_t* currentInSearch = root;
   while(true){
-    if (strcmp(name, currentInSearch->name)==0){
+    if (strcmp(name, currentInSearch->name) == STRCMP_SAME){
       currentInSearch->f(); // Call function assoc with handler
       break;
     }
-    if(currentInSearch->next == 0){
+    if(currentInSearch->next == nullptr){
       break;
     }
     currentInSearch = currentInSearch->next;
@@ -68,7 +80,7 @@ void Conduit::callHandler(const char* name){
 
 Conduit& Conduit::init(){
   this->_client = &pClient;
-  pClient.setServer(this->_mqtt_server, 1883);
+  pClient.setServer(this->_mqtt_server, SERVER_DEFAULT_PORT);
   Serial.println("Happened");
   pClient.setCallback([&](char* topic, byte* payload, unsigned int length){
     Serial.print("Message arrived [");
@@ -102,7 +114,7 @@ void Conduit::reconnect() {
     if (this->_client->connect(this->_prefixed_name)) {
       Serial.println("connected");
       // Once connected, publish an announcement...
-      this->_client->publish("outTopic", "hello world");
+      this->_client->publish(DEFAULT_TOPIC_NAME, ON_CONNECT_MSG);
       // Suscribe to topics:
       this->_client->subscribe(this->_prefixed_name); // suscribe to events meant for this device
     } else {
@@ -110,23 +122,23 @@ void Conduit::reconnect() {
       Serial.print(this->_client->state());
       Serial.println(" try again in 5 seconds"); 
       // Wait 5 seconds before retrying
-      delay(5000);
+      delay(RECONNECT_DELAY_MS);
     }
   }
 }
 
 void Conduit::publishMessage(const char* message){
-  char str[40];
+  char str[STATIC_STRING_CHARS];
   strcpy(str, this->_prefixed_name);
-  strcat(str, "/device");
+  strcat(str, DEVICE_PATH_SUFFIX);
   const char* topicName = str;
   this->_client->publish(topicName, message);
 }
 
 void Conduit::publishData(const char* message, const char* dataStream) { 
-	char topicBuffer[40];
+	char topicBuffer[STATIC_STRING_CHARS];
 	strcpy(topicBuffer, this->_prefixed_name);
-	strcat(topicBuffer, "/stream/");
+	strcat(topicBuffer, STREAM_PATH_INFIX);
 	strcat(topicBuffer, dataStream);
 	const char* topicName = topicBuffer;
 	this->_client->publish(topicName, message);
@@ -138,7 +150,7 @@ void Conduit::startWIFI(const char* ssid, const char* password){
 
   // Wait for connection
   while (WiFi.status() != WL_CONNECTED) {
-    delay(500);
+    delay(CONNECT_DELAY_MS);
     Serial.print(".");
   }
 

--- a/firmware/src/Conduit.cpp
+++ b/firmware/src/Conduit.cpp
@@ -17,11 +17,15 @@ device and decide what funciton to all is abstracted away entirely by this libra
 #define RECONNECT_DELAY_MS    5000
 #define CONNECT_DELAY_MS      500
 #define ROOT_NODE_NAME        "ROOT"
+
+// These values are required for interop with Conduit (conduit.suyash.io)!
+// DO NOT CHANGE THESE
 #define DEVICE_PATH_SUFFIX    "/device"
 #define STREAM_PATH_INFIX     "/stream/"
 #define DEFAULT_TOPIC_NAME    "outTopic"
 #define ON_CONNECT_MSG        "!connected"
-#define SERVER_DEFAULT_PORT   1883
+#define SERVER_DEFAULT_PORT   1883  
+
 #define STRCMP_SAME           0
 
 typedef struct node {

--- a/firmware/src/Conduit.h
+++ b/firmware/src/Conduit.h
@@ -15,7 +15,7 @@ device and decide what funciton to all is abstracted away entirely by this libra
 #include <WiFiClient.h>
 #include <ESP8266WiFi.h> 
 
-typedef int (*handler)();
+typedef void (*handler)();
 void removeSpace(char* s);
 
 

--- a/firmware/src/Conduit.h
+++ b/firmware/src/Conduit.h
@@ -15,7 +15,7 @@ device and decide what funciton to all is abstracted away entirely by this libra
 #include <WiFiClient.h>
 #include <ESP8266WiFi.h> 
 
-typedef void (*handler)();
+typedef int (*handler)();
 void removeSpace(char* s);
 
 

--- a/firmware/src/main.ino
+++ b/firmware/src/main.ino
@@ -10,10 +10,10 @@ device and decide what funciton to all is abstracted away entirely by this libra
 @author: Suyash Kumar <suyashkumar2003@gmail.com>
 */
 #include <Arduino.h> 
-#include <wifi_info.h> // You can include secret wifi info in a seperate file 
+// #include <wifi_info.h> // You can include secret wifi info in a seperate file 
 #include <Conduit.h>
 
-#define LED D0
+#define LED D1
 
 // Fill out the below Github folks:
 //const char* ssid = "mywifi";
@@ -26,7 +26,7 @@ Conduit conduit(deviceName, serverUrl, apiKey); // init Conduit
 int ledStatus = 0;
 
 // Toggles an LED attached on the LED pin!
-int ledToggle(){
+void ledToggle(){
   digitalWrite(LED, (ledStatus) ? LOW : HIGH);
   ledStatus = (ledStatus) ? 0 : 1;
   Serial.println("Toggled");
@@ -35,7 +35,7 @@ int ledToggle(){
 
 // Publishes a message response to the server 
 // when this function is called
-int publishMessage(){
+void publishMessage(){
     conduit.publishMessage("hey there");
 }
 
@@ -43,7 +43,7 @@ int publishMessage(){
 // sends data to the "testing" datastream
 // to be persisted in a database on the server
 // sends a "Done" response when done
-int publishSomeData(){
+void publishSomeData(){
 	conduit.publishData("10", "testing");
 	conduit.publishMessage("Done");
 }

--- a/firmware/src/main.ino
+++ b/firmware/src/main.ino
@@ -13,7 +13,7 @@ device and decide what funciton to all is abstracted away entirely by this libra
 // #include <wifi_info.h> // You can include secret wifi info in a seperate file 
 #include <Conduit.h>
 
-#define LED D1
+#define LED D0
 
 // Fill out the below Github folks:
 //const char* ssid = "mywifi";

--- a/firmware/src/main.ino
+++ b/firmware/src/main.ino
@@ -26,7 +26,7 @@ Conduit conduit(deviceName, serverUrl, apiKey); // init Conduit
 int ledStatus = 0;
 
 // Toggles an LED attached on the LED pin!
-void ledToggle(){
+int ledToggle(){
   digitalWrite(LED, (ledStatus) ? LOW : HIGH);
   ledStatus = (ledStatus) ? 0 : 1;
   Serial.println("Toggled");
@@ -35,7 +35,7 @@ void ledToggle(){
 
 // Publishes a message response to the server 
 // when this function is called
-void publishMessage(){
+int publishMessage(){
     conduit.publishMessage("hey there");
 }
 
@@ -43,7 +43,7 @@ void publishMessage(){
 // sends data to the "testing" datastream
 // to be persisted in a database on the server
 // sends a "Done" response when done
-void publishSomeData(){
+int publishSomeData(){
 	conduit.publishData("10", "testing");
 	conduit.publishMessage("Done");
 }


### PR DESCRIPTION
Change handler function signature to void-return and move a ton of "magic values" (such as port numbers, delay times, path names, string sizes, etc.) into #defines that will be easier to change and identify in the future.