### PR TITLE
General Refactor and Cleanup

### DIFF
--- a/server/app/conduit.go
+++ b/server/app/conduit.go
@@ -2,82 +2,60 @@ package app
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/julienschmidt/httprouter"
 	"github.com/suyashkumar/conduit/server/handlers"
-	"github.com/suyashkumar/conduit/server/middleware"
 	"github.com/suyashkumar/conduit/server/mqtt"
-	"github.com/suyashkumar/conduit/server/secrets"
 	"gopkg.in/mgo.v2"
-	"net/http"
-	"os"
 )
 
-type AppConfig struct {
-	IsDev bool
+type App interface {
+	Run() error
 }
 
-type ConduitApp interface {
-	Run()
+type app struct {
+	config  Config
+	router  *httprouter.Router
+	context *handlers.Context
 }
 
-type ConduitAppImpl struct {
-	AppConfig
-	Router  *httprouter.Router
-	context *handlers.HandlerContext
+type Config struct {
+	IsDev     bool
+	Port      string
+	CertKey   string
+	PrivKey   string
+	DBDialURL string
 }
 
-func (c *ConduitAppImpl) Run() {
-	c.attachRoutes()
-	mqtt.RunServer()
-	c.startWebServer()
-}
-
-func (c *ConduitAppImpl) attachRoutes() {
-	c.Router.GET("/api/send/:deviceName/:funcName", c.WrapAuthHandler(handlers.Send))
-	c.Router.GET("/api/streams/:deviceName/:streamName", c.WrapAuthHandler(handlers.GetStreamedMessages))
-	c.Router.POST("/api/auth", c.WrapHandler(handlers.Auth))
-	c.Router.POST("/api/register", c.WrapHandler(handlers.New))
-	c.Router.GET("/api/me", c.WrapAuthHandler(handlers.GetUser))
-	c.Router.GET("/", handlers.Hello)
-	c.Router.OPTIONS("/api/*sendPath", handlers.Headers)
-	c.Router.ServeFiles("/static/*filepath", http.Dir("public/static"))
-}
-
-func (c *ConduitAppImpl) WrapAuthHandler(next handlers.AuthHandler) httprouter.Handle {
-	return middleware.ConduitAuthMiddleware(next, c.context)
-}
-
-func (c *ConduitAppImpl) WrapHandler(next handlers.ConduitHandler) httprouter.Handle {
-	return middleware.ConduitMiddleware(next, c.context)
-}
-
-func (c *ConduitAppImpl) startWebServer() {
-	fmt.Printf("Web server to listen on port :%s", os.Getenv("PORT"))
-	if c.AppConfig.IsDev {
-		err := http.ListenAndServe(":"+os.Getenv("PORT"), c.Router)
-		panic(err)
-	} else {
-		go http.ListenAndServeTLS(":443", os.Getenv("CERT"), os.Getenv("PRIV_KEY"), c.Router)
-		err := http.ListenAndServe(":"+os.Getenv("PORT"), http.HandlerFunc(handlers.RedirectToHttps))
-		panic(err)
-	}
-
-}
-
-func NewConduitApp() *ConduitAppImpl {
-	// Init DB Session
-	session, err := mgo.Dial(secrets.DB_DIAL_URL)
+func New(c Config) (*app, error) {
+	// Initialize DB Session
+	session, err := mgo.Dial(c.DBDialURL)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return &ConduitAppImpl{
-		Router: httprouter.New(),
-		AppConfig: AppConfig{
-			IsDev: os.Getenv("DEV") == "TRUE",
-		},
-		context: &handlers.HandlerContext{
-			DbSession: session,
-		},
+	// Initialize Context
+	ctx := &handlers.Context{DbSession: session}
+
+	// Initialize Router
+	r := httprouter.New()
+	attachRoutes(r, ctx)
+
+	return &app{
+		router: r,
+		config: c,
+	}, nil
+}
+
+func (a *app) Run() error {
+	mqtt.RunServer()
+
+	fmt.Printf("Web server to listen on port :%s", a.config.Port)
+	if a.config.IsDev {
+		return http.ListenAndServe(":"+a.config.Port, a.router)
+	} else {
+		go http.ListenAndServeTLS(":443", a.config.CertKey, a.config.PrivKey, a.router)
+		return http.ListenAndServe(":"+a.config.Port, http.HandlerFunc(handlers.RedirectToHttps))
 	}
 }

--- a/server/handlers/auth.go
+++ b/server/handlers/auth.go
@@ -27,11 +27,6 @@ type HomeAutoClaims struct {
 	jwt.StandardClaims
 }
 
-type ErrorResponse struct {
-	Success bool   `json:"success"`
-	Error   string `json:"error"`
-}
-
 type TokenResponse struct {
 	Success bool   `json:"success"`
 	Token   string `json:"token"`
@@ -44,28 +39,9 @@ type UserResponse struct {
 	Key     string `json:"key"`
 }
 
-type HandlerContext struct {
-	DbSession *mgo.Session
-}
-
-type AuthHandler func(
-	http.ResponseWriter,
-	*http.Request,
-	httprouter.Params,
-	*HandlerContext,
-	*HomeAutoClaims,
-)
-
-type ConduitHandler func(
-	http.ResponseWriter,
-	*http.Request,
-	httprouter.Params,
-	*HandlerContext,
-)
-
 // Handler to create a new conduit user in the database, along with
 // a generated private Prefix
-func New(w http.ResponseWriter, r *http.Request, ps httprouter.Params, context *HandlerContext) {
+func New(w http.ResponseWriter, r *http.Request, ps httprouter.Params, context *Context) {
 	SetCorsHeaders(w)
 	u, err := decodeUserFromRequest(r)
 	if err != nil {
@@ -86,7 +62,7 @@ func New(w http.ResponseWriter, r *http.Request, ps httprouter.Params, context *
 
 // Handler to return user information stored inside a
 // JSON Web Token
-func GetUser(w http.ResponseWriter, r *http.Request, ps httprouter.Params, context *HandlerContext, hc *HomeAutoClaims) {
+func GetUser(w http.ResponseWriter, r *http.Request, ps httprouter.Params, context *Context, hc *HomeAutoClaims) {
 	u := UserResponse{
 		Success: true,
 		Message: "You're authenticated",
@@ -103,7 +79,7 @@ func GetUser(w http.ResponseWriter, r *http.Request, ps httprouter.Params, conte
 
 // Handler to authenticate users to conduit and issue them
 // a JSON Web Token if successful
-func Auth(w http.ResponseWriter, r *http.Request, ps httprouter.Params, context *HandlerContext) {
+func Auth(w http.ResponseWriter, r *http.Request, ps httprouter.Params, context *Context) {
 	SetCorsHeaders(w)
 	u, err := decodeUserFromRequest(r)
 	if err != nil {

--- a/server/handlers/dataStreams.go
+++ b/server/handlers/dataStreams.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-func GetStreamedMessages(w http.ResponseWriter, r *http.Request, ps httprouter.Params, context *HandlerContext, hc *HomeAutoClaims) {
+func GetStreamedMessages(w http.ResponseWriter, r *http.Request, ps httprouter.Params, context *Context, hc *HomeAutoClaims) {
 	session := context.DbSession.New()
 	defer session.Close()
 

--- a/server/handlers/deviceMessaging.go
+++ b/server/handlers/deviceMessaging.go
@@ -21,15 +21,15 @@ func PrefixedName(deviceName string, prefix string) string {
 	return prefix + deviceName
 }
 
-func Send(w http.ResponseWriter, r *http.Request, ps httprouter.Params, context *HandlerContext, hc *HomeAutoClaims) {
+func Send(w http.ResponseWriter, r *http.Request, ps httprouter.Params, context *Context, hc *HomeAutoClaims) {
 
 	prefixedName := PrefixedName(ps.ByName("deviceName"), hc.Prefix)
 
-	mqtt.Client().SendMessage(prefixedName, ps.ByName("funcName"))
+	mqtt.GetClient().SendMessage(prefixedName, ps.ByName("funcName"))
 
 	c := make(chan string)
 
-	mqtt.Client().Register(prefixedName+"/device", func(topic string, payload string) {
+	mqtt.GetClient().Register(prefixedName+"/device", func(topic string, payload string) {
 		defer func() {
 			if r := recover(); r != nil {
 				log.Println("Error in device response handler", r)
@@ -59,7 +59,7 @@ func Send(w http.ResponseWriter, r *http.Request, ps httprouter.Params, context 
 	}
 
 	// Cleanup:
-	err := mqtt.Client().DeRegister(prefixedName + "/device")
+	err := mqtt.GetClient().DeRegister(prefixedName + "/device")
 	if err != nil {
 		fmt.Println("Issues deregistering device message listener")
 	}

--- a/server/handlers/types.go
+++ b/server/handlers/types.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"gopkg.in/mgo.v2"
+)
+
+type Context struct {
+	DbSession *mgo.Session
+}
+
+type AuthHandler func(
+	http.ResponseWriter,
+	*http.Request,
+	httprouter.Params,
+	*Context,
+	*HomeAutoClaims,
+)
+
+type Handler func(
+	http.ResponseWriter,
+	*http.Request,
+	httprouter.Params,
+	*Context,
+)
+
+type ErrorResponse struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error"`
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,10 +1,35 @@
 package main
 
 import (
+	"os"
+
+	"fmt"
+
 	"github.com/suyashkumar/conduit/server/app"
+	"github.com/suyashkumar/conduit/server/secrets"
 )
 
 func main() {
-	conduitApp := app.NewConduitApp() // Init a new conduit web service
-	conduitApp.Run()                  // Run the conduit web service server
+	// Create Conduit App configuration
+	c := app.Config{
+		IsDev:     os.Getenv("DEV") == "TRUE",
+		Port:      os.Getenv("PORT"),
+		CertKey:   os.Getenv("CERT"),
+		PrivKey:   os.Getenv("PRIV_KEY"),
+		DBDialURL: secrets.DB_DIAL_URL,
+	}
+
+	// Create new app
+	app, err := app.New(c)
+	if err != nil {
+		fmt.Println("Issue creating New app")
+		panic(err)
+	}
+
+	// Run app
+	err = app.Run()
+	if err != nil {
+		fmt.Println("Issue running app")
+		panic(err)
+	}
 }

--- a/server/tests/handlers_test.go
+++ b/server/tests/handlers_test.go
@@ -2,12 +2,12 @@ package tests
 
 import (
 	"encoding/json"
-	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/suyashkumar/conduit/server/handlers"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/suyashkumar/conduit/server/handlers"
 )
 
 func TestMain(m *testing.M) {
@@ -27,9 +27,8 @@ func TestGetUser(t *testing.T) {
 	sampleEmail := "test@suyash.io"
 	samplePrefix := "myPrefix"
 	hc := handlers.HomeAutoClaims{Email: sampleEmail, Prefix: samplePrefix}
-	context := handlers.HandlerContext{}
+	context := handlers.Context{}
 	handlers.GetUser(w, req, nil, &context, &hc)
-	fmt.Println(w.Body.String())
 	var user handlers.UserResponse
 	err := json.Unmarshal(w.Body.Bytes(), &user)
 	assert.Nil(t, err)


### PR DESCRIPTION
This change is mostly a cleanup change and refactors the application to be more "go canoical" as I tend to like it. Structs and interfaces are named better, and packages behave and are organized a bit better. This addresses many of the issues in #41 in the `app`, `mqtt`, and `handlers` packages. 