### PR TITLE
Implement device responses, groundwork for sending params to device

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,1 @@
+conduit

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
 from golang:1.9
-WORKDIR /go/src/app
+WORKDIR /go/src/github.com/suyashkumar/conduit/server
 RUN go get -u github.com/golang/dep/cmd/dep
 COPY . .
 RUN make

--- a/server/Gopkg.lock
+++ b/server/Gopkg.lock
@@ -14,16 +14,6 @@
   version = "v1.2.0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/graarh/golang-socketio"
-  packages = [
-    ".",
-    "protocol",
-    "transport"
-  ]
-  revision = "2c44953b9b5fcd4da83ec8816f002ce68a12ef2d"
-
-[[projects]]
   name = "github.com/jinzhu/gorm"
   packages = [
     ".",
@@ -52,7 +42,7 @@
     "hstore",
     "oid"
   ]
-  revision = "b2004221932bd6b13167ef654c81cffac36f7537"
+  revision = "d34b9ff171c21ad295489235aec8b6626023cd04"
 
 [[projects]]
   name = "github.com/rifflock/lfshook"
@@ -80,13 +70,23 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/suyashkumar/golang-socketio"
+  packages = [
+    ".",
+    "protocol",
+    "transport"
+  ]
+  revision = "d319f78bb742e7375eef96a20a99bcdfff0c922d"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
     "blowfish",
     "ssh/terminal"
   ]
-  revision = "80db560fac1fb3e6ac81dbc7f8ae4c061f5257bd"
+  revision = "e73bf333ef8920dbb52ad18d4bd38ad9d9bc76d7"
 
 [[projects]]
   branch = "master"
@@ -95,11 +95,11 @@
     "unix",
     "windows"
   ]
-  revision = "c488ab1dd8481ef762f96a79a9577c27825be697"
+  revision = "79b0c6888797020a994db17c8510466c72fe75d9"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3a1bfbbf316356e94c9ba09686199aae13508c9b351f5ee5e0a01dcc7cff7503"
+  inputs-digest = "8c8dfdebe20182cf02adfce986f28815a4bc07b24aa395e449a5d880fee1e411"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/server/device/callbacks.go
+++ b/server/device/callbacks.go
@@ -1,8 +1,8 @@
 package device
 
 import (
-	"github.com/graarh/golang-socketio"
 	"github.com/sirupsen/logrus"
+	"github.com/suyashkumar/golang-socketio"
 )
 
 const OK_MSG = "OK"

--- a/server/entities/requests.go
+++ b/server/entities/requests.go
@@ -11,7 +11,8 @@ type LoginRequest struct {
 }
 
 type CallRequest struct {
-	Token        string `json:"token"`
-	DeviceName   string `json:"device_name"`
-	FunctionName string `json:"function_name"`
+	Token                 string `json:"token"`
+	DeviceName            string `json:"device_name"`
+	FunctionName          string `json:"function_name"`
+	WaitForDeviceResponse bool   `json:"wait_for_device_response"`
 }

--- a/server/entities/responses.go
+++ b/server/entities/responses.go
@@ -12,3 +12,7 @@ type ErrorResponse struct {
 type LoginResponse struct {
 	Token string `json:"token"`
 }
+
+type SendResponse struct {
+	Response string `json:"response"`
+}

--- a/server/handlers/api_handlers.go
+++ b/server/handlers/api_handlers.go
@@ -5,6 +5,8 @@ import (
 
 	"encoding/json"
 
+	"time"
+
 	"github.com/julienschmidt/httprouter"
 	"github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
@@ -125,6 +127,24 @@ func Call(w http.ResponseWriter, r *http.Request, ps httprouter.Params, d device
 		return
 	}
 
-	d.Call(req.DeviceName, claims.Data["accountSecret"], req.FunctionName)
-	sendOK(w)
+	c := d.Call(req.DeviceName, claims.Data["accountSecret"], req.FunctionName, req.WaitForDeviceResponse)
+
+	if req.WaitForDeviceResponse {
+		select {
+		case res := <-c:
+			logrus.WithField("response", res).Infof("Device responded")
+			r := entities.SendResponse{
+				Response: res,
+			}
+			sendJSON(w, r, 200)
+		case <-time.After(3 * time.Second):
+			logrus.Warn("Timed out waiting for device response")
+			e := entities.ErrorResponse{
+				Error: "Timed out while waiting for the device to respond",
+			}
+			sendJSON(w, e, 500)
+		}
+	} else {
+		sendOK(w)
+	}
 }

--- a/server/handlers/api_handlers.go
+++ b/server/handlers/api_handlers.go
@@ -132,7 +132,7 @@ func Call(w http.ResponseWriter, r *http.Request, ps httprouter.Params, d device
 	if req.WaitForDeviceResponse {
 		select {
 		case res := <-c:
-			logrus.WithField("response", res).Infof("Device responded")
+			logrus.WithField("response", res).Info("Device responded")
 			r := entities.SendResponse{
 				Response: res,
 			}


### PR DESCRIPTION
This change allows devices running the conduit firmware to respond to RPCs issued by the conduit web service (closes #60). This change also begins to lay to groundwork to pass parameters to RPCs called on devices (#59)